### PR TITLE
[BZZRWRDD-305] Support Image type creative in sample

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation "com.buzzvil:buzzad-benefit:1.4.0-rc.5"
+    implementation "com.buzzvil:buzzad-benefit:1.4.0-rc.6"
 
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation "com.android.support:design:26.1.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation "com.buzzvil:buzzad-benefit:1.3.5"
+    implementation "com.buzzvil:buzzad-benefit:1.4.0-rc.5"
 
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation "com.android.support:design:26.1.0"

--- a/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/MainActivity.java
+++ b/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/MainActivity.java
@@ -70,6 +70,7 @@ public class MainActivity extends AppCompatActivity {
                         .adsAdapterClass(CustomAdsAdapter.class)
                         .feedToolbarHolderClass(CustomFeedToolbarHolder.class)
                         .feedHeaderViewAdapterClass(CustomFeedHeaderViewAdapter.class)
+                        .imageTypeEnabled(true)
                         .build();
                 final FeedHandler feedHandler = new FeedHandler(feedConfig);
                 feedHandler.startFeedActivity(MainActivity.this);

--- a/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/MainActivity.java
+++ b/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/MainActivity.java
@@ -114,7 +114,7 @@ public class MainActivity extends AppCompatActivity {
                 MainActivity.this.adView = interstitialAdView;
                 ((ViewGroup) findViewById(android.R.id.content)).addView(adView);
             }
-        });
+        }, true);
     }
 
     private void loadNativeAds() {

--- a/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/feed/CustomAdsAdapter.java
+++ b/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/feed/CustomAdsAdapter.java
@@ -62,7 +62,8 @@ public class CustomAdsAdapter extends AdsAdapter<AdsAdapter.NativeAdViewHolder> 
         final CtaPresenter ctaPresenter = new CtaPresenter(ctaView);
         ctaPresenter.bind(nativeAd);
 
-        if (Creative.Type.IMAGE.equals(ad.getCreative().getType())) {
+        final Creative.Type creativeType = ad.getCreative() == null ? null : ad.getCreative().getType();
+        if (Creative.Type.IMAGE.equals(creativeType)) {
             titleLayout.setVisibility(View.GONE);
             descriptionView.setVisibility(View.GONE);
         } else {

--- a/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/feed/CustomAdsAdapter.java
+++ b/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/feed/CustomAdsAdapter.java
@@ -7,10 +7,13 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.bumptech.glide.Glide;
 import com.buzzvil.buzzad.benefit.core.models.Ad;
+import com.buzzvil.buzzad.benefit.core.models.Creative;
 import com.buzzvil.buzzad.benefit.presentation.feed.ad.AdsAdapter;
 import com.buzzvil.buzzad.benefit.presentation.media.CtaPresenter;
 import com.buzzvil.buzzad.benefit.presentation.media.CtaView;
@@ -19,9 +22,8 @@ import com.buzzvil.buzzad.benefit.presentation.nativead.NativeAd;
 import com.buzzvil.buzzad.benefit.presentation.nativead.NativeAdView;
 import com.buzzvil.buzzad.benefit.presentation.video.VideoErrorStatus;
 import com.buzzvil.buzzad.benefit.sample.publisher.R;
-import com.nostra13.universalimageloader.core.ImageLoader;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 
 public class CustomAdsAdapter extends AdsAdapter<AdsAdapter.NativeAdViewHolder> {
@@ -39,38 +41,40 @@ public class CustomAdsAdapter extends AdsAdapter<AdsAdapter.NativeAdViewHolder> 
 
         final Ad ad = nativeAd.getAd();
         final MediaView mediaView = view.findViewById(R.id.mediaView);
+        final LinearLayout titleLayout = view.findViewById(R.id.titleLayout);
         final TextView titleView = view.findViewById(R.id.textTitle);
         final ImageView iconView = view.findViewById(R.id.imageIcon);
         final TextView descriptionView = view.findViewById(R.id.textDescription);
         final CtaView ctaView = view.findViewById(R.id.ctaView);
 
-        if (mediaView != null) {
-            mediaView.setCreative(ad.getCreative());
-            mediaView.addOnMediaErrorListener(new MediaView.OnMediaErrorListener() {
-                @Override
-                public void onVideoError(@NonNull MediaView mediaView, @NonNull VideoErrorStatus videoErrorStatus, @Nullable String errorMessage) {
-                    if (errorMessage != null) {
-                        Toast.makeText(mediaView.getContext(), errorMessage, Toast.LENGTH_SHORT).show();
-                    }
+        mediaView.setCreative(ad.getCreative());
+        mediaView.addOnMediaErrorListener(new MediaView.OnMediaErrorListener() {
+            @Override
+            public void onVideoError(@NonNull MediaView mediaView, @NonNull VideoErrorStatus videoErrorStatus, @Nullable String errorMessage) {
+                if (errorMessage != null) {
+                    Toast.makeText(mediaView.getContext(), errorMessage, Toast.LENGTH_SHORT).show();
                 }
-            });
-        }
-        if (titleView != null) {
-            titleView.setText(ad.getTitle());
-        }
-        if (iconView != null) {
-            ImageLoader.getInstance().displayImage(ad.getIconUrl(), iconView);
-        }
-        if (descriptionView != null) {
-            descriptionView.setText(ad.getDescription());
+            }
+        });
+        titleView.setText(ad.getTitle());
+        descriptionView.setText(ad.getDescription());
+        Glide.with(holder.itemView).load(ad.getIconUrl()).into(iconView);
+        final CtaPresenter ctaPresenter = new CtaPresenter(ctaView);
+        ctaPresenter.bind(nativeAd);
+
+        if (Creative.Type.IMAGE.equals(ad.getCreative().getType())) {
+            titleLayout.setVisibility(View.GONE);
+            descriptionView.setVisibility(View.GONE);
+        } else {
+            titleLayout.setVisibility(View.VISIBLE);
+            descriptionView.setVisibility(View.VISIBLE);
         }
 
-        if (ctaView != null) {
-            final CtaPresenter presenter = new CtaPresenter(ctaView);
-            presenter.bind(nativeAd);
-        }
-
-        final Collection<View> clickableViews = Arrays.asList((View) ctaView);
+        final Collection<View> clickableViews = new ArrayList<>();
+        clickableViews.add(ctaView);
+        clickableViews.add(mediaView);
+        clickableViews.add(titleLayout);
+        clickableViews.add(descriptionView);
 
         view.setNativeAd(nativeAd);
         view.setMediaView(mediaView);

--- a/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/nativead/InterstitialAdView.java
+++ b/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/nativead/InterstitialAdView.java
@@ -90,6 +90,9 @@ public class InterstitialAdView extends FrameLayout {
         if (Creative.Type.IMAGE.equals(ad.getCreative().getType())) {
             titleLayout.setVisibility(View.GONE);
             descriptionTextView.setVisibility(View.GONE);
+        } else {
+            titleLayout.setVisibility(View.VISIBLE);
+            descriptionTextView.setVisibility(View.VISIBLE);
         }
 
         final List<View> clickableViews = new ArrayList<>();

--- a/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/nativead/InterstitialAdView.java
+++ b/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/nativead/InterstitialAdView.java
@@ -87,7 +87,8 @@ public class InterstitialAdView extends FrameLayout {
         final CtaPresenter ctaPresenter = new CtaPresenter(ctaView);
         ctaPresenter.bind(nativeAd);
 
-        if (Creative.Type.IMAGE.equals(ad.getCreative().getType())) {
+        final Creative.Type creativeType = ad.getCreative() == null ? null : ad.getCreative().getType();
+        if (Creative.Type.IMAGE.equals(creativeType)) {
             titleLayout.setVisibility(View.GONE);
             descriptionTextView.setVisibility(View.GONE);
         } else {

--- a/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/nativead/InterstitialAdView.java
+++ b/app/src/main/java/com/buzzvil/buzzad/benefit/sample/publisher/nativead/InterstitialAdView.java
@@ -13,6 +13,7 @@ import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 import com.buzzvil.buzzad.benefit.core.models.Ad;
+import com.buzzvil.buzzad.benefit.core.models.Creative;
 import com.buzzvil.buzzad.benefit.presentation.media.CtaPresenter;
 import com.buzzvil.buzzad.benefit.presentation.media.CtaView;
 import com.buzzvil.buzzad.benefit.presentation.media.MediaView;
@@ -28,9 +29,10 @@ public class InterstitialAdView extends FrameLayout {
 
     private NativeAdView nativeAdView;
     private MediaView mediaView;
+    private View titleLayout;
+    private ImageView iconImageView;
     private TextView titleTextView;
     private TextView descriptionTextView;
-    private ImageView iconImageView;
     private CtaView ctaView;
 
     public interface OnCloseClickListener {
@@ -48,9 +50,10 @@ public class InterstitialAdView extends FrameLayout {
         LayoutInflater.from(context).inflate(R.layout.view_interstitial_ad, this);
         this.nativeAdView = findViewById(R.id.native_ad_view);
         this.mediaView = findViewById(R.id.ad_media_view);
+        this.titleLayout = findViewById(R.id.ad_title_layout);
+        this.iconImageView = findViewById(R.id.ad_icon_image);
         this.titleTextView = findViewById(R.id.ad_title_text);
         this.descriptionTextView = findViewById(R.id.ad_description_text);
-        this.iconImageView = findViewById(R.id.ad_icon_image);
         this.ctaView = findViewById(R.id.ad_cta_view);
         findViewById(R.id.ad_close_text).setOnClickListener(new View.OnClickListener() {
             @Override
@@ -84,10 +87,15 @@ public class InterstitialAdView extends FrameLayout {
         final CtaPresenter ctaPresenter = new CtaPresenter(ctaView);
         ctaPresenter.bind(nativeAd);
 
+        if (Creative.Type.IMAGE.equals(ad.getCreative().getType())) {
+            titleLayout.setVisibility(View.GONE);
+            descriptionTextView.setVisibility(View.GONE);
+        }
+
         final List<View> clickableViews = new ArrayList<>();
         clickableViews.add(ctaView);
         clickableViews.add(mediaView);
-        clickableViews.add(titleTextView);
+        clickableViews.add(titleLayout);
         clickableViews.add(descriptionTextView);
 
         nativeAdView.setMediaView(mediaView);

--- a/app/src/main/res/layout/view_interstitial_ad.xml
+++ b/app/src/main/res/layout/view_interstitial_ad.xml
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#80000000"
-    android:clickable="true"
     android:padding="20dp">
 
     <com.buzzvil.buzzad.benefit.presentation.nativead.NativeAdView
         android:id="@+id/native_ad_view"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical">
+        card_view:layout_constraintBottom_toBottomOf="parent"
+        card_view:layout_constraintEnd_toEndOf="parent"
+        card_view:layout_constraintStart_toStartOf="parent"
+        card_view:layout_constraintTop_toTopOf="parent">
 
         <FrameLayout
             android:layout_width="match_parent"
@@ -30,6 +32,7 @@
                     android:orientation="vertical">
 
                     <TextView
+                        android:id="@+id/card_title_text"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="40dp"
@@ -41,7 +44,7 @@
                         android:id="@+id/ad_media_view"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="24dp"
+                        android:layout_marginTop="12dp"
                         android:minHeight="100dp" />
 
                     <LinearLayout
@@ -80,12 +83,13 @@
                         android:layout_marginLeft="16dp"
                         android:layout_marginTop="12dp"
                         android:layout_marginRight="16dp"
+                        android:layout_marginBottom="28dp"
                         android:textColor="@android:color/black" />
 
                     <FrameLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="40dp"
+                        android:layout_marginTop="12dp"
                         android:layout_marginBottom="16dp">
 
                         <TextView
@@ -124,4 +128,4 @@
 
     </com.buzzvil.buzzad.benefit.presentation.nativead.NativeAdView>
 
-</FrameLayout>
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/view_interstitial_ad.xml
+++ b/app/src/main/res/layout/view_interstitial_ad.xml
@@ -45,6 +45,7 @@
                         android:minHeight="100dp" />
 
                     <LinearLayout
+                        android:id="@+id/ad_title_layout"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginLeft="16dp"


### PR DESCRIPTION
- Interstitial module 의 정책과 동일하게, Native 타입의 샘플 중에서 intersitialAdView 에서만 ImageType 을 enable 시켰습니다.
- Feed 에서 CustomAdsAdapter 를 쓰고 있었으므로 그 안에 ImageType 을 서포트하는 로직을 추가했습니다.
- Native sample screenshot
![KakaoTalk_Photo_2019-03-19-18-47-07](https://user-images.githubusercontent.com/16411248/54596179-75d57d80-4a77-11e9-8972-2772b54e3826.jpeg)
- Feed sample screenshot
![KakaoTalk_Photo_2019-03-19-18-47-11](https://user-images.githubusercontent.com/16411248/54596180-75d57d80-4a77-11e9-986a-c835a9ba029f.jpeg)